### PR TITLE
Bring over most recent changes from .org repo.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,33 +7,46 @@ Tags: wufoo, form, shortcode
 Author URI: http://wufoo.com
 Author: Chris Coyier
 Requires at least: 2.6
-Tested up to: 3.2.1
-Stable tag: 1.1
-Version: 1.1
+Tested up to: 3.3.1
+Stable tag: 1.42
+Version: 1.42
 
 Allows the use of a special short code [wufoo] for embedding Wufoo forms.
 
 == Description ==
 
-Allows the use of a special short code [wufoo] for embedding Wufoo forms. It's best to grab the shortcode from the Wufoo Code Manager (coming soon!).
+Allows the use of a special short code [wufoo] for embedding Wufoo forms. It's best to grab the shortcode from the Wufoo Code Manager.
 
-**Usage:** `[wufoo username="chriscoyier" formhash="x7w3w3" autoresize="true" height="458" header="show" ssl="true"]`
+**Example:** 
+`[wufoo username="examples" formhash="z7w4r7" autoresize="true" height="517" header="show" ssl="true"]`
 
-But again, it's best to grab the code directly from the Wufoo [Code Manager](http://wufoo.com/docs/code-manager/) (coming soon).
+For advanced users, you can pre-set Wufoo form values with an extra parameter:
+`defaultv="Field1=Bob&Field2=Sandwich Eater"`
 
 == Installation ==
 
-For old school manual installation people: copy the folder "wufoo_shortcode" into the /wp-content/plugins/ folder. Then go to the Plugins area of the Admin and activate.
+For old school manual installation people: copy the folder "wufoo_shortcode" into the /wp-content/plugins/ folder. Then go to the Plugins area of the Admin and activate. Otherwise, search for "Wufoo Shortcode Plugin" from the admin area of your WordPress site in Plugins > Add New.
 
 == Screenshots ==
 
-http://cl.ly/97Pz
+1. Usage of shortcode example
+2. Where to get shortcode
 
 == Changelog ==
 
 1.0 - Initial release.
 
 1.1 - SSL param isn't included in snippet if not passed. Gratis and Ad Hoc Wufoo users don't use that param, as SSL is not offered.
+
+1.2 - Adding ability to pre-set fields via extra Default Values parameter
+
+1.3 - Added no JavaScript fallback
+
+1.4 - Making JavaScript embed async
+
+1.41 - Bugfix: stop hardcoding subdomain
+
+1.42 - Improvements to plugin
 
 == Frequently Asked Questions ==
 
@@ -45,4 +58,4 @@ http://cl.ly/97Pz
 
 Shortcodes are clean! You can already copy and paste JavaScript or iframe code to embed a Wufoo form onto a WordPress page, but you need to make sure to be in the "HTML" tab of the writing area. If a user is in the "Visual" (default) tab, the embed code will not work. Short codes will work either way.
 
-We also hope that this is the first step to WordPress.com integration (wink, wink).
+This plugin duplicates what is already possible on WordPress.com.

--- a/wufoo.php
+++ b/wufoo.php
@@ -1,8 +1,8 @@
 <?php
 /*
 Plugin Name: Wufoo Shortcode Plugin
-Description: Enables shortcode to embed Wufoo forms. Usage: <code>[wufoo username="chriscoyier" formhash="x7w3w3" autoresize="true" height="458" header="show" ssl="true"]</code>. Soon, you'll be able to grab this from the Wufoo Code Manager.
-Version: 0.2
+Description: Enables shortcode to embed Wufoo forms. Usage: <code>[wufoo username="chriscoyier" formhash="x7w3w3" autoresize="true" height="458" header="show" ssl="true"]</code>. This code is available to copy and paste directly from the Wufoo Code Manager.
+Version: 1.42
 License: GPL
 Author: Chris Coyier / Wufoo
 Author URI: http://wufoo.com
@@ -11,51 +11,87 @@ Author URI: http://wufoo.com
 function createWufooEmbedJS($atts, $content = null) {
 	extract(shortcode_atts(array(
 		'username'   => '',
-		'formhash'   => '', 
+		'formhash'   => '',
 		'autoresize' => true,
 		'height'     => '500',
-		'header'     => 'show', 
-		'ssl'        => ''
+		'header'     => 'show',
+		'ssl'        => '',
+		'defaultv'   => '',
+		'entsource'  => 'wordpress',
 	), $atts));
-	
+
 	if (!$username or !$formhash) {
-		
+
 		$error = "
 		<div style='border: 20px solid red; border-radius: 40px; padding: 40px; margin: 50px 0 70px;'>
 			<h3>Uh oh!</h3>
 			<p style='margin: 0;'>Something is wrong with your Wufoo shortcode. If you copy and paste it from the <a href='http://wufoo.com/docs/code-manager/'>Wufoo Code Manager</a>, you should be golden.</p>
 		</div>";
-		
+
 		return $error;
-		
+
 	} else {
-		
-		$JSEmbed = '<script type="text/javascript">var host = (("https:" == document.location.protocol) ? "https://secure." : "http://");document.write(unescape("%3Cscript src=\'" + host + "wufoo.com/scripts/embed/form.js\'  type=\'text/javascript\'%3E%3C/script%3E"));</script>';
-	
-		$JSEmbed .= "<script type='text/javascript'>";
-		$JSEmbed .= "var $formhash = new WufooForm();";
-		$JSEmbed .= "$formhash.initialize({";
-		$JSEmbed .= "'userName':'$username', ";
-		$JSEmbed .= "'formHash':'$formhash', ";
-		$JSEmbed .= "'autoResize':$autoresize,";
-		$JSEmbed .= "'height':'$height',";
-		$JSEmbed .= "'header':'$header' ";
-		
+
+		$JSEmbed =  "<div id='wufoo-$formhash'>\n";
+		$JSEmbed .= "Fill out my <a href='http://$username.wufoo.com/forms/$formhash'>online form</a>.\n";
+		$JSEmbed .=  "</div>\n";
+
+		$JSEmbed .= "<script type='text/javascript'>var $formhash;(function(d, t) {\n";
+		$JSEmbed .= "var s = d.createElement(t), options = {\n";
+		$JSEmbed .= "'userName'      : '$username',    \n";
+		$JSEmbed .= "'formHash'      : '$formhash',    \n";
+		$JSEmbed .= "'autoResize'    :  $autoresize,   \n";
+		$JSEmbed .= "'height'        : '$height',      \n";
+		$JSEmbed .= "'async'         :  true,          \n";
+		$JSEmbed .= "'header'        : '$header',      \n";
+		$JSEmbed .= "'host'          : 'wufoo.com',    \n";
+		$JSEmbed .= "'entSource'     : '$entsource',   \n";
+		$JSEmbed .= "'defaultValues' : '$defaultv'     \n";
+
 		// Only output SSL value if passes as param
 		// Gratis and Ad Hoc plans don't show that param (don't offer SSL)
 		if ($ssl) {
-			$JSEmbed .= ",'ssl':$ssl";
+			$JSEmbed .= ",'ssl'          :  $ssl           ";
 		}
-		
-		$JSEmbed .= "});";
-		
-		$JSEmbed .= "$formhash.display();";
-		$JSEmbed .= "</script>";
-		
-		return $JSEmbed;
-	
+		$JSEmbed .= "};\n";
+
+		$JSEmbed .= "s.src = ('https:' == d.location.protocol ? 'https://' : 'http://') + 'wufoo.com/scripts/embed/form.js';\n";
+		$JSEmbed .= "s.onload = s.onreadystatechange = function() {\n";
+		$JSEmbed .= "var rs = this.readyState; if (rs) if (rs != 'complete') if (rs != 'loaded') return;\n";
+		$JSEmbed .= "try { $formhash = new WufooForm();$formhash.initialize(options);$formhash.display(); } catch (e) {}}\n";
+		$JSEmbed .= "var scr = d.getElementsByTagName(t)[0], par = scr.parentNode; par.insertBefore(s, scr);\n";
+		$JSEmbed .= "})(document, 'script');</script>";
+
+		/**
+		 * iframe embed, loaded inside <noscript> tags
+		 */
+		$iframe_embed = '<iframe ';
+		$iframe_embed .= 'height="'. (int) $height .'" ';
+		$iframe_embed .= 'allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none;"';
+		$iframe_embed .= 'src="https://'. $username .'.wufoo.com/embed/'. $formhash . '/';
+		if (isset($defaultv) && $defaultv != ''){
+			$iframe_embed .= "def/$defaultv&entsource=wordpress\">";
+		}
+		else{
+			$iframe_embed .= "def/entsource=wordpress\">";
+		}
+		$iframe_embed .= '<a href="https://'. $username .'.wufoo.com/forms/'. $formhash .'/';
+		if (isset($defaultv) && $defaultv != ''){
+			$iframe_embed .= "def/$defaultv&entsource=wordpress\" ";
+		}
+		else{
+			$iframe_embed .= "def/entsource=wordpress\" ";
+		}
+		$iframe_embed .= 'rel="nofollow">Fill out my Wufoo form!</a></iframe>';
+
+		/**
+		 * Return embed in JS and iframe
+		 */
+		return "$JSEmbed <noscript> $iframe_embed </noscript>";
+
 	}
 }
+
 add_shortcode('wufoo', 'createWufooEmbedJS');
 
 ?>


### PR DESCRIPTION
Updating the plugin here on GitHub to match what is on the .org repo. Main reason for this is we've made some clean up changes, mostly escaping changes, to the main plugin and would like to push those back. But those are based off of the most recent plugin on .org, so need those changes brought in first. Another pull request will be sent with the escaping changes.
